### PR TITLE
getString was missing an "l" for "global"

### DIFF
--- a/lib/view/EntityControl/RgbColorSelector.dart
+++ b/lib/view/EntityControl/RgbColorSelector.dart
@@ -102,7 +102,7 @@ class _RgbColorSelectorState extends State<RgbColorSelector> {
         ),
         actions: <Widget>[
           RaisedButton(
-            child: Text(Translate.getString("globa.reset", context)),
+            child: Text(Translate.getString("global.reset", context)),
             onPressed: () {
               setState(
                 () {


### PR DESCRIPTION
A typo in Translate.getString()