### PR TITLE
User selectable launch tab

### DIFF
--- a/lib/helper/general_data.dart
+++ b/lib/helper/general_data.dart
@@ -1462,6 +1462,7 @@ class GeneralData with ChangeNotifier {
   }
 
   DeviceSetting deviceSetting = DeviceSetting(
+    launchIndex: 0,
     phoneLayout: 3,
     tabletLayout: 69,
     shapeLayout: 1,
@@ -1488,6 +1489,7 @@ class GeneralData with ChangeNotifier {
       deviceSetting = DeviceSetting.fromJson(val);
     } else {
       log.w('CAN NOT FIND deviceSetting adding default data');
+      deviceSetting.launchIndex = 0;
       deviceSetting.phoneLayout = 3;
       deviceSetting.tabletLayout = 69;
       deviceSetting.shapeLayout = 1;
@@ -1508,6 +1510,7 @@ class GeneralData with ChangeNotifier {
 
     try {
       var jsonDeviceSetting = {
+        'launchIndex': deviceSetting.launchIndex,
         'phoneLayout': deviceSetting.phoneLayout,
         'tabletLayout': deviceSetting.tabletLayout,
         'shapeLayout': deviceSetting.shapeLayout,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -399,6 +399,7 @@ class _HomeViewState extends State<HomeView> with WidgetsBindingObserver {
         DeviceOrientation.portraitUp,
       ]);
     }
+    if(showLoading) return Container();
     log.w(
         "gd.isTablet ${gd.isTablet} gd.mediaQueryShortestSide ${gd.mediaQueryShortestSide} gd.mediaQueryLongestSide ${gd.mediaQueryLongestSide} orientation ${gd.mediaQueryOrientation}");
     return Selector<GeneralData, String>(
@@ -406,6 +407,7 @@ class _HomeViewState extends State<HomeView> with WidgetsBindingObserver {
           "${generalData.viewMode} | " +
           "${Localizations.localeOf(context).languageCode} | " +
           "${generalData.deviceSetting.settingLocked} | " +
+          "${generalData.deviceSetting.launchIndex} | " +
           "${generalData.deviceSetting.phoneLayout} | " +
           "${generalData.deviceSetting.tabletLayout} | " +
           "${generalData.deviceSetting.shapeLayout} | " +
@@ -429,7 +431,8 @@ class _HomeViewState extends State<HomeView> with WidgetsBindingObserver {
                   log.d("CupertinoTabBar onTap $int");
                   gd.viewMode = ViewMode.normal;
                 },
-                currentIndex: 0,
+                // currentIndex: 0,
+                currentIndex: gd.deviceSetting.launchIndex,
                 items: [
                   BottomNavigationBarItem(
                     icon: Icon(MaterialDesignIcons.getIconDataFromIconName(

--- a/lib/model/device_setting.dart
+++ b/lib/model/device_setting.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 class DeviceSetting {
+  int launchIndex = 0;
   int phoneLayout = 3;
   int tabletLayout = 69;
   int shapeLayout = 1;
@@ -13,6 +14,7 @@ class DeviceSetting {
   List<String> backgroundPhoto = [];
 
   DeviceSetting({
+    @required this.launchIndex,
     @required this.phoneLayout,
     @required this.tabletLayout,
     @required this.shapeLayout,
@@ -26,6 +28,7 @@ class DeviceSetting {
   });
 
   Map<String, dynamic> toJson() => {
+        'launchIndex': launchIndex,
         'phoneLayout': phoneLayout,
         'tabletLayout': tabletLayout,
         'shapeLayout': shapeLayout,
@@ -40,6 +43,7 @@ class DeviceSetting {
 
   factory DeviceSetting.fromJson(Map<String, dynamic> json) {
     return DeviceSetting(
+      launchIndex: json['launchIndex'] != null ? json['launchIndex'] : 0,
       phoneLayout: json['phoneLayout'] != null ? json['phoneLayout'] : 3,
       tabletLayout: json['tabletLayout'] != null ? json['tabletLayout'] : 69,
       shapeLayout: json['shapeLayout'] != null ? json['shapeLayout'] : 1,

--- a/lib/view/setting_page.dart
+++ b/lib/view/setting_page.dart
@@ -121,6 +121,7 @@ class _SettingPageState extends State<SettingPage> {
           "${generalData.currentTheme} | "
           "${generalData.webSocketConnectionStatus} | "
           "${generalData.deviceSetting.settingLocked} | "
+          "${generalData.deviceSetting.launchIndex} | "
           "${generalData.deviceSetting.phoneLayout} | "
           "${generalData.deviceSetting.tabletLayout} | "
           "${generalData.deviceSetting.shapeLayout} | "
@@ -368,6 +369,13 @@ class _SettingPageState extends State<SettingPage> {
               ),
               ShapeSelector(),
               LayoutSelector(),
+              SliverHeaderNormal(
+                icon: Icon(
+                  MaterialDesignIcons.getIconDataFromIconName("mdi:launch"),
+                ),
+                title: "Launch",
+              ),
+              LaunchSelector(),
               SliverHeaderNormal(
                 icon: Icon(
                   MaterialDesignIcons.getIconDataFromIconName("mdi:web"),
@@ -746,6 +754,53 @@ class _ShapeSelectorState extends State<ShapeSelector> {
                 });
               },
               groupValue: gd.deviceSetting.shapeLayout,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class LaunchSelector extends StatefulWidget {
+  @override
+  _LaunchSelectorState createState() => _LaunchSelectorState();
+}
+
+class _LaunchSelectorState extends State<LaunchSelector> {
+
+
+  int launchValue;
+
+  @override
+  Widget build(BuildContext context) {
+    launchValue = gd.deviceSetting.launchIndex;
+
+  final Map<int, Widget> launchSegment = <int, Widget>{
+    0: Text(gd.getRoomName(0)),
+    1: Text(Translate.getString("global.rooms", context))
+  };
+
+    return SliverList(
+      delegate: SliverChildListDelegate(
+        [
+          Container(
+            margin: EdgeInsets.all(8),
+            padding: EdgeInsets.all(8),
+            decoration: BoxDecoration(
+                color: ThemeInfo.colorBottomSheet.withOpacity(0.5),
+                borderRadius: BorderRadius.circular(8)),
+            child: CupertinoSlidingSegmentedControl<int>(
+                thumbColor: ThemeInfo.colorIconActive,
+                backgroundColor: Colors.transparent,
+                children: launchSegment,
+                onValueChanged: (int val) {
+                  setState(() {
+                    gd.deviceSetting.launchIndex = val;
+                    gd.deviceSettingSave();
+                  });
+                },
+                groupValue: gd.deviceSetting.launchIndex,
             ),
           ),
         ],


### PR DESCRIPTION
This lets the user pick whether they want the app to launch to the Home or Rooms tab.  I was only able to test this on the android emulator.  A couple things:

- I just added the title "Launch" to the settings page.  I didn't include the language translate as I didn't know if adding a new value would mess up all the languages
- I couldn't change the currentindex of the CupertinoTabBar after it was already drawn.  So in main.dart, if the app is still loading I am returning an empty container.  Not sure if this is the best way or not.