### PR TITLE
support white value for RGBW lights

### DIFF
--- a/lib/model/entity.dart
+++ b/lib/model/entity.dart
@@ -46,6 +46,7 @@ class Entity {
   //Light
   int supportedFeatures;
   double brightness;
+  double whiteValue;
   List<int> rgbColor;
   int minMireds;
   int maxMireds;
@@ -120,6 +121,7 @@ class Entity {
     //light
     this.supportedFeatures,
     this.brightness,
+    this.whiteValue,
     this.rgbColor,
     this.minMireds,
     this.maxMireds,
@@ -255,6 +257,10 @@ class Entity {
         brightness:
             double.tryParse(json['attributes']['brightness'].toString()) != null
                 ? double.parse(json['attributes']['brightness'].toString())
+                : null,
+        whiteValue:
+            double.tryParse(json['attributes']['white_value'].toString()) != null
+                ? double.parse(json['attributes']['white_value'].toString())
                 : null,
         rgbColor: json['attributes']['rgb_color'] != null
             ? List<int>.from(json['attributes']['rgb_color'])
@@ -837,10 +843,11 @@ class Entity {
     var openPercent = "";
     if (isStateOn &&
         entityId.contains("light.") &&
-        brightness != null &&
-        brightness > 0) {
+        ((brightness != null &&
+        brightness > 0) || (whiteValue != null &&
+        whiteValue > 0))) {
       openPercent = " " +
-          gd.mapNumber(brightness, 0, 254, 0, 100).toStringAsFixed(0) +
+          gd.mapNumber(brightness > whiteValue? brightness : whiteValue, 0, 254, 0, 100).toStringAsFixed(0) +
           "%";
     }
     if (isStateOn &&

--- a/lib/view/entity_control/entity_control_light_dimmer.dart
+++ b/lib/view/entity_control/entity_control_light_dimmer.dart
@@ -146,6 +146,7 @@ class LightSliderState extends State<LightSlider> {
       selector: (_, generalData) =>
           "${generalData.entities[widget.entityId].state} " +
           "${generalData.entities[widget.entityId].brightness} " +
+          "${generalData.entities[widget.entityId].whiteValue} " +
           "${generalData.entities[widget.entityId].colorTemp} " +
           "${generalData.entities[widget.entityId].rgbColor} ",
       builder: (context, data, child) {
@@ -159,7 +160,7 @@ class LightSliderState extends State<LightSlider> {
             buttonValue = lowerPartHeight;
           } else {
             var mapValue = gd.mapNumber(
-                gd.entities[widget.entityId].brightness.toDouble(),
+              widget.viewMode == "SUPPORT_COLOR_TEMP" ? gd.entities[widget.entityId].whiteValue.toDouble() : gd.entities[widget.entityId].brightness.toDouble(),
                 0,
                 254,
                 lowerPartHeight,
@@ -329,7 +330,7 @@ class LightSliderState extends State<LightSlider> {
             "service": "turn_on",
             "service_data": {
               "entity_id": entity.entityId,
-              "brightness": sendValue.toInt()
+              widget.viewMode == "SUPPORT_COLOR_TEMP"? "white_value" : "brightness": sendValue.toInt()
             },
           };
         }


### PR DESCRIPTION
Add the ability to control/display white value.  For my outdoor lights, I typically have the brightness turned down to 0 and the white value turned all the way up.  This lets me just use the white channels on my bulbs.  In Hasskit is always showed as 0% because of the brightness.  This pull request does 2 things:

1. On the room page, it'll show either the brightness% or whiteValue%...whichever is greater
2. The dimmer slider controls the whiteValue when the "Temp" mode is selected.  RGB mode still controls the brightness.

Note: sliding either slider all the way down will send the turn_off command.  Note sure the best way to handle that if user wants one all the way turned down.  I'm also reusing the same icon for both sliders as I wasn't sure if a white value icon would be needed or not.